### PR TITLE
Include binary runtime dependencies to the RPM specfile

### DIFF
--- a/syncstar.spec
+++ b/syncstar.spec
@@ -13,6 +13,10 @@ BuildArch:      noarch
 
 BuildRequires:  python3-devel
 
+Requires:       coreutils
+Requires:       util-linux
+Requires:       redis
+
 %description
 %{desc}
 


### PR DESCRIPTION
Include binary runtime dependencies to the RPM specfile