### PR TITLE
Fix the sources of the regular italicised typeface

### DIFF
--- a/syncstar/frontend/template/home.html
+++ b/syncstar/frontend/template/home.html
@@ -39,7 +39,7 @@
         font-family: "Inter";
         font-weight: 400;
         font-style: italic;
-        src: url("{{ url_for('static', filename='font/sans_ital.ttf') }}");
+        src: url("{{ url_for('static', filename='font/sans_rlit.ttf') }}");
       }
 
       @font-face {
@@ -67,7 +67,7 @@
         font-family: "JetBrains Mono";
         font-weight: 400;
         font-style: italic;
-        src: url("{{ url_for('static', filename='font/mono_ital.ttf') }}");
+        src: url("{{ url_for('static', filename='font/mono_rlit.ttf') }}");
       }
 
       @font-face {


### PR DESCRIPTION
Fix the sources of the regular italicised typeface

It used to look like the following 

![image](https://github.com/gridhead/syncstar/assets/49605954/4b5043a5-0427-4a67-99be-5a0c0ebfedab)

Now it looks like the following

![image](https://github.com/gridhead/syncstar/assets/49605954/8153ea74-df24-437b-9c2f-6ae8d5e0608d)

Is it not amazing?

WDYM - No?