### PR TITLE
Start Celery worker from the entrypoint command

### DIFF
--- a/syncstar/config/__init__.py
+++ b/syncstar/config/__init__.py
@@ -30,20 +30,16 @@ from syncstar import view
 from syncstar.config import standard
 
 
-def keep_config(port: int, repair: bool, period: int) -> None:
+def apim_config(port: int, period: int) -> None:
     # Generate a secret code for the frontend to authenticate with the service
     standard.code = urandom(8).hex().upper()
 
     # Keep the configuration variables served in the command for consumption
     standard.port = port
-    standard.repair = repair
     standard.period = period
-    if repair:
-        standard.logrconf["handlers"]["console"]["level"] = "DEBUG"
-        standard.logrconf["root"]["level"] = "DEBUG"
 
 
-def isos_config(images: str) -> None:
+def main_config(images: str, source: str, repair: bool) -> None:
     # Check the validity of the images configuration file before saving the contents
     if path.exists(images):
         with open(images) as yamlfile:
@@ -69,3 +65,9 @@ def isos_config(images: str) -> None:
     else:
         view.failure("Images configuration file not detected")
         exit(1)
+
+    standard.source = standard.broker_link = standard.result_link = source
+    standard.repair = repair
+    if repair:
+        standard.logrconf["handlers"]["console"]["level"] = "DEBUG"
+        standard.logrconf["root"]["level"] = "DEBUG"

--- a/syncstar/config/standard.py
+++ b/syncstar/config/standard.py
@@ -44,8 +44,9 @@ lockls = []
 
 code = "0000000000000000"
 
-broker_link = "redis://localhost:6379/0"
-result_link = "redis://localhost:6379/0"
+source = "redis://localhost:6379/0"
+broker_link = source
+result_link = source
 
 # Variables used for the testing purposes
 

--- a/syncstar/task.py
+++ b/syncstar/task.py
@@ -24,13 +24,12 @@ or replicated with the express permission of Red Hat, Inc.
 import signal
 import subprocess
 import traceback
-from os import environ as envr
 from time import sleep, time
 
 from celery import Celery
 from celery.exceptions import Ignore
 
-from syncstar import __projname__, base, config
+from syncstar import __projname__, base
 from syncstar.config import standard
 
 taskmgmt = Celery(
@@ -42,7 +41,6 @@ taskmgmt = Celery(
 
 @taskmgmt.task(bind=True)
 def wrap_diskdrop(self, diskindx: str, isosindx: str) -> dict:
-    config.isos_config(envr["SYNCSTAR_ISOSYAML"])
     isosfile = standard.imdict[isosindx]["path"]
     diskfile = base.list_drives()[diskindx]["node"]
 

--- a/test/test_isos.py
+++ b/test/test_isos.py
@@ -26,7 +26,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from syncstar.config import isos_config, standard
+from syncstar.config import main_config, standard
 
 
 @pytest.mark.parametrize(
@@ -67,9 +67,13 @@ from syncstar.config import isos_config, standard
             ],
             id="ISOSCONFIG Function - Negative ISOSYAML configuration - Empty config",
         ),
+
     ]
 )
 def test_isos(caplog, work, text):
+    # TODO - Add checks for the `source` parameter specific usages of the `main_config` function
+    # TODO - Add checks for the `repair` parameter specific usages of the `main_config` function
+
     # Foundation
     backup_images, backup_imdict = standard.images, standard.imdict
 
@@ -78,7 +82,7 @@ def test_isos(caplog, work, text):
         if work == 0:   temppath = "/usr/bin/zeroexistent"
         else:           temppath = "/usr/bin/python3"
         with pytest.raises(SystemExit) as func:
-            isos_config(temppath)
+            main_config(temppath, standard.source, standard.repair)
             assert func.value.code == 1
     else:
         with TemporaryDirectory(prefix="syncstar-test-") as tempdrct:
@@ -93,10 +97,10 @@ def test_isos(caplog, work, text):
 
             if work != 2:
                 with pytest.raises(SystemExit) as func:
-                    isos_config(temppath)
+                    main_config(temppath, standard.source, standard.repair)
                     assert func.value.code == 1
             else:
-                isos_config(temppath)
+                main_config(temppath, standard.source, standard.repair)
 
     # Initialization & Confirmation
     for indx in text:

--- a/test/test_keep.py
+++ b/test/test_keep.py
@@ -23,7 +23,7 @@ or replicated with the express permission of Red Hat, Inc.
 
 import pytest
 
-from syncstar.config import keep_config, standard
+from syncstar.config import apim_config, standard
 
 
 @pytest.mark.parametrize(
@@ -50,14 +50,11 @@ def test_keep(port, repair, period, severity):
     backup_port, backup_repair, backup_period, backup_logrconf = standard.port, standard.repair, standard.period, standard.logrconf
 
     # Initialization
-    keep_config(port, repair, period)
+    apim_config(port, period)
 
     # Confirmation
     assert standard.port == port
-    assert standard.repair == repair
     assert standard.period == period
-    assert standard.logrconf["handlers"]["console"]["level"] == severity
-    assert standard.logrconf["root"]["level"] == severity
 
     # Teardown
     standard.port, standard.repair, standard.period, standard.logrconf = backup_port, backup_repair, backup_period, backup_logrconf

--- a/test/test_meet.py
+++ b/test/test_meet.py
@@ -23,9 +23,8 @@ or replicated with the express permission of Red Hat, Inc.
 
 import pytest
 
-from syncstar import __versdata__
 from syncstar.config import standard
-from syncstar.main import meet
+from syncstar.main import meet_apim, meet_cell
 
 
 @pytest.mark.parametrize(
@@ -36,34 +35,32 @@ from syncstar.main import meet
             standard.period,
             standard.repair,
             [
-                f"Starting SyncStar v{__versdata__}...",
                 f"Use the secret code '{standard.code}' to authenticate with the service",
                 f"Information on the frontend would be refreshed every after {standard.period} second(s)",
                 f"Debug mode is {'enabled' if standard.repair else 'disabled'}",
             ],
-            id="MEET Function - Standard parameters"
+            id="MEET_APIM Function - Standard parameters"
         ),
         pytest.param(
             "XXXXXXXXXXXXXXXX",
             10,
             True,
             [
-                f"Starting SyncStar v{__versdata__}...",
                 "Use the secret code 'XXXXXXXXXXXXXXXX' to authenticate with the service",
                 "Information on the frontend would be refreshed every after 10 second(s)",
                 "Debug mode is enabled",
             ],
-            id="MEET Function - Modified parameters"
+            id="MEET_APIM Function - Modified parameters"
         ),
     ]
 )
-def test_meet(caplog, code, period, repair, output):
+def test_meet_apim(caplog, code, period, repair, output):
     # Foundation
     backup_code, backup_period, backup_repair = standard.code, standard.period, standard.repair
 
     # Initialization
     standard.code, standard.period, standard.repair = code, period, repair
-    meet()
+    meet_apim()
 
     # Confirmation
     for indx in output:
@@ -71,3 +68,46 @@ def test_meet(caplog, code, period, repair, output):
 
     # Teardown
     standard.code, standard.period, standard.repair = backup_code, backup_period, backup_repair
+
+
+@pytest.mark.parametrize(
+    "images, source, output",
+    [
+        pytest.param(
+            standard.images,
+            standard.source,
+            [
+                f"Images config - '{standard.images}'",
+                f"Broker source - '{standard.broker_link}'",
+                f"Result source - '{standard.result_link}'",
+            ],
+            id="MEET_CELL Function - Standard parameters"
+        ),
+        pytest.param(
+            "/etc/zeroexistent",
+            "/etc/zeroexistent",
+            [
+                "Images config - '/etc/zeroexistent'",
+                "Broker source - '/etc/zeroexistent'",
+                "Result source - '/etc/zeroexistent'",
+            ],
+            id="MEET_CELL Function - Modified parameters"
+        ),
+    ]
+)
+def test_meet_cell(caplog, images, source, output):
+    # Foundation
+    backup_images, backup_source = standard.images, standard.source
+
+    # Initialization
+    standard.images = images
+    standard.broker_link, standard.result_link = source, source
+    meet_cell()
+
+    # Confirmation
+    for indx in output:
+        assert indx in caplog.text
+
+    # Teardown
+    standard.images, standard.source = backup_images, backup_source
+    standard.broker_link, standard.result_link = backup_source, backup_source

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -109,7 +109,7 @@ def test_task(mocker, work):
         }
     }
     mocker.patch("celery.Task.update_state", return_value=mock_update_state)
-    mocker.patch("syncstar.config.isos_config", return_value=True)
+    mocker.patch("syncstar.config.main_config", return_value=True)
     mocker.patch("subprocess.Popen", return_value=MockProcess())
 
     # Confirmation

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ commands =
 
 [coverage:report]
 exclude_also =
-    keep_config()
-    isos_config()
+    apim_config()
+    main_config()
     meet()
     work()
 


### PR DESCRIPTION
Fixes #42

Here is what the basic help looks like

```
Usage: syncstar [OPTIONS] COMMAND [ARGS]...

Options:
  -i, --images PATH     Set the location to where the images config is stored
                        [required]
  -s, --source PATH     Set the location where tasks will be exchanged
                        [default: redis://localhost:6379/0]
  -r, --repair BOOLEAN  Show the nerdy statistics to help repair the codebase
                        [default: False]
  --version             Show the version and exit.
  --help                Show this message and exit.

Commands:
  apim  Start the frontend service
  cell  Start the worker service
```

Here is what the help for the `apim` option looks like

```
[2024-06-17 02:57:36 +0530] Starting SyncStar v0.1.0a2...
[2024-06-17 02:57:36 +0530] Checking image file for 'Fedora Server Rawhide'...
[2024-06-17 02:57:36 +0530] Checking image file for 'Fedora Everything 38'...
Usage: syncstar apim [OPTIONS]

  Start the frontend service

Options:
  -p, --port INTEGER RANGE    Set the port value for the service frontend
                              endpoints  [default: 8080; 64<=x<=65535]
  -t, --period INTEGER RANGE  Set the period after which the info will be
                              refreshed  [default: 2; 2<=x<=30]
  --help                      Show this message and exit.
```

Here is what the help for the `cell` option looks like

```
[2024-06-17 02:58:40 +0530] Starting SyncStar v0.1.0a2...
[2024-06-17 02:58:40 +0530] Checking image file for 'Fedora Server Rawhide'...
[2024-06-17 02:58:40 +0530] Checking image file for 'Fedora Everything 38'...
Usage: syncstar cell [OPTIONS]

  Start the worker service

Options:
  --help  Show this message and exit.
```